### PR TITLE
🐛(git) fix guideline for the commit message of a new release

### DIFF
--- a/git.md
+++ b/git.md
@@ -145,22 +145,22 @@ Whatever the language you are using on a FUN project, cooking a new release \(_e
 
 4. Commit your changes with a structured message:
 
-- add a title including the version of the release and respecting the above described format using the 🔖 release emoji,
-- paste in the body all changes from the changelog concerned by this release, removing only the markdown tags and making sure that lines are shorter than 74 characters.
+    - add a title including the version of the release and respecting the above described format using the 🔖 release emoji,
+    - paste in the body all changes from the changelog concerned by this release, removing only the markdown tags and making sure that lines are shorter than 74 characters.
 
-```
-🔖(minor) Bump release to 4.18.0
+        ```
+        🔖(minor) Bump release to 4.18.0
 
-Added:
+        Added:
 
- - Implement base CLI commands (list, extract, fetch & push) for supported
- backends
- - Support for ElasticSearch database backend
- 
-Changed:
+        - Implement base CLI commands (list, extract, fetch & push) for supported
+        backends
+        - Support for ElasticSearch database backend
+        
+        Changed:
 
- - Replace LDP storage backend by FS storage backend
-```
+        - Replace LDP storage backend by FS storage backend
+        ```
 
 5. Open a pull or merge request depending on the current forge of the project,
 


### PR DESCRIPTION
## Purpose
Markdown render is not the way expected. Fix to properly
present how to add all the statements that are concerned
in the changelog file directly in the commit message.

## Proposal
Adding indentation, here you can see the preview of the modification directly from gitbook 

![Capture d’écran 2021-01-20 à 10 03 04](https://user-images.githubusercontent.com/76939263/105151833-b9cbba80-5b06-11eb-8ba2-63f2a81e791c.png)
